### PR TITLE
Swap drivers redesign, WAIVER transaction logging, identity redirect

### DIFF
--- a/client/pages/[season]/identity.tsx
+++ b/client/pages/[season]/identity.tsx
@@ -29,7 +29,7 @@ const IdentityPage = ({ constructors }: Props) => {
   const router = useRouter()
   const { query } = router
   const season = query.season as string
-  const redirect = (query.redirect as string) || `/${season}/standings`
+  const redirect = query.redirect as string | undefined
   const hasImages = HAS_IMAGES_BY_SEASON[season]
   const [currentIdentityId, setCurrentIdentityId] = useState<number | null>(
     null
@@ -55,7 +55,12 @@ const IdentityPage = ({ constructors }: Props) => {
       IDENTITY_KEY,
       JSON.stringify({ ...current, [season]: value })
     )
-    router.replace(redirect)
+    const destination =
+      redirect ||
+      `/${season}/constructors/${constructor.id}-${encodeURIComponent(
+        normalizeConstructorName(constructor.name)
+      )}`
+    router.replace(destination)
   }
 
   const currentConstructor = constructors.find(

--- a/client/pages/[season]/swap-drivers.tsx
+++ b/client/pages/[season]/swap-drivers.tsx
@@ -43,6 +43,8 @@ const SwapDrivers = ({
   const [swapResponse, setSwapResponse] = useState<Data>()
   const [identityLoaded, setIdentityLoaded] = useState<boolean>(false)
   const [driverSearch, setDriverSearch] = useState<string>('')
+  const [localSelectedDrivers, setLocalSelectedDrivers] =
+    useState(selectedDrivers)
 
   useEffect(() => {
     if (!season) return
@@ -66,7 +68,7 @@ const SwapDrivers = ({
   }, [season, isAdmin])
 
   const managingConstructor = constructors.find((c) => c.id === constructorId)
-  const currentDrivers = selectedDrivers.find(
+  const currentDrivers = localSelectedDrivers.find(
     (cd) => cd.constructor_id === constructorId
   )
   const currentDriverList = currentDrivers
@@ -323,6 +325,22 @@ const SwapDrivers = ({
                 const data = await resp.json()
                 setSwapResponse(data)
                 if (data.success) {
+                  setLocalSelectedDrivers((prev) =>
+                    prev.map((cd) => {
+                      if (cd.constructor_id !== constructorId) return cd
+                      return {
+                        ...cd,
+                        driver_one:
+                          cd.driver_one.id === oldDriverId
+                            ? newDriver!
+                            : cd.driver_one,
+                        driver_two:
+                          cd.driver_two.id === oldDriverId
+                            ? newDriver!
+                            : cd.driver_two,
+                      }
+                    })
+                  )
                   setOldDriverId(undefined)
                   setNewDriverId(undefined)
                   setDriverSearch('')

--- a/client/pages/[season]/swap-drivers.tsx
+++ b/client/pages/[season]/swap-drivers.tsx
@@ -88,15 +88,58 @@ const SwapDrivers = ({
   const primaryColor = colors?.primary ?? '#6b7280'
   const { red, blue, green } = hexRgb(primaryColor)
   const hasImages = HAS_IMAGES_BY_SEASON[season]
-  const carImageUrl = normalized
-    ? hasImages
+  const carImageUrl =
+    normalized && hasImages
       ? getCloudinaryCarUrl(normalized, season, { format: 'webp' })
       : rgbDataURL(red, green, blue)
-    : rgbDataURL(red, green, blue)
 
   const filteredAvailableDrivers = localAvailableDrivers.filter((d) =>
     makeName(d).toLowerCase().includes(driverSearch.toLowerCase())
   )
+
+  const handleSwap = async () => {
+    setIsSwapping(true)
+    try {
+      const resp = await fetch(
+        `/api/drivers/swap?season=${season}&constructor_id=${constructorId}&old_driver_id=${oldDriverId}&new_driver_id=${newDriverId}${
+          isAdmin ? '&admin=true' : ''
+        }`,
+        { method: 'POST' }
+      )
+      const data = await resp.json()
+      setSwapResponse(data)
+      if (data.success) {
+        setLocalSelectedDrivers((prev) =>
+          prev.map((cd) => {
+            if (cd.constructor_id !== constructorId) return cd
+            return {
+              ...cd,
+              driver_one:
+                cd.driver_one.id === oldDriverId ? newDriver! : cd.driver_one,
+              driver_two:
+                cd.driver_two.id === oldDriverId ? newDriver! : cd.driver_two,
+            }
+          })
+        )
+        setLocalAvailableDrivers((prev) =>
+          [
+            ...prev.filter((d) => d.id !== newDriverId),
+            oldDriver! as unknown as DriverWithSeason,
+          ].sort((a, b) => a.last_name.localeCompare(b.last_name))
+        )
+        setOldDriverId(undefined)
+        setNewDriverId(undefined)
+        setDriverSearch('')
+      }
+    } catch {
+      setSwapResponse({
+        success: false,
+        message: 'Network error, please try again',
+      })
+    } finally {
+      setIsSwapping(false)
+    }
+  }
 
   if (!identityLoaded) {
     return (
@@ -315,54 +358,7 @@ const SwapDrivers = ({
           <button
             type='button'
             disabled={disableButton}
-            onClick={async () => {
-              setIsSwapping(true)
-              try {
-                const resp = await fetch(
-                  `/api/drivers/swap?season=${season}&constructor_id=${constructorId}&old_driver_id=${oldDriverId}&new_driver_id=${newDriverId}${
-                    isAdmin ? '&admin=true' : ''
-                  }`,
-                  { method: 'POST' }
-                )
-                const data = await resp.json()
-                setSwapResponse(data)
-                if (data.success) {
-                  setLocalSelectedDrivers((prev) =>
-                    prev.map((cd) => {
-                      if (cd.constructor_id !== constructorId) return cd
-                      return {
-                        ...cd,
-                        driver_one:
-                          cd.driver_one.id === oldDriverId
-                            ? newDriver!
-                            : cd.driver_one,
-                        driver_two:
-                          cd.driver_two.id === oldDriverId
-                            ? newDriver!
-                            : cd.driver_two,
-                      }
-                    })
-                  )
-                  setLocalAvailableDrivers((prev) => {
-                    const withoutNew = prev.filter((d) => d.id !== newDriverId)
-                    return [
-                      ...withoutNew,
-                      oldDriver! as unknown as DriverWithSeason,
-                    ].sort((a, b) => a.last_name.localeCompare(b.last_name))
-                  })
-                  setOldDriverId(undefined)
-                  setNewDriverId(undefined)
-                  setDriverSearch('')
-                }
-              } catch {
-                setSwapResponse({
-                  success: false,
-                  message: 'Network error, please try again',
-                })
-              } finally {
-                setIsSwapping(false)
-              }
-            }}
+            onClick={handleSwap}
             className='mt-6 w-full px-6 py-3 text-xl text-white bg-green-700 rounded-lg hover:bg-green-800 focus:outline-none focus:ring-4 focus:ring-green-300 disabled:opacity-50 disabled:cursor-not-allowed font-secondary'
           >
             {isSwapping ? 'Swapping...' : 'Confirm Swap'}

--- a/client/pages/[season]/swap-drivers.tsx
+++ b/client/pages/[season]/swap-drivers.tsx
@@ -1,17 +1,25 @@
 import Layout from '@/components/Layout'
-import { IDENTITY_KEY, IdentityValue } from '@/pages/[season]/identity'
+import { COLORS_BY_CONSTRUCTOR, HAS_IMAGES_BY_SEASON } from '@/constants/index'
+import {
+  getCloudinaryCarUrl,
+  normalizeConstructorName,
+  rgbDataURL,
+} from '@/helpers/cars'
 import { constructorColumns } from '@/helpers/supabase'
 import { getSeasonParam, makeName } from '@/helpers/utils'
 import { supabase } from '@/lib/database'
 import { Data } from '@/pages/api/drivers/swap'
+import { IDENTITY_KEY, IdentityValue } from '@/pages/[season]/identity'
 import {
   ConstructorDriverWithJoins,
   ConstructorWithSeason,
   DriverWithSeason,
 } from '@/types/Unions'
+import hexRgb from 'hex-rgb'
 import { GetServerSidePropsContext } from 'next'
+import Image from 'next/image'
 import { useRouter } from 'next/router'
-import { Fragment, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 interface Props {
   constructors: ConstructorWithSeason[]
@@ -34,9 +42,14 @@ const SwapDrivers = ({
   const [isSwapping, setIsSwapping] = useState<boolean>(false)
   const [swapResponse, setSwapResponse] = useState<Data>()
   const [identityLoaded, setIdentityLoaded] = useState<boolean>(false)
+  const [driverSearch, setDriverSearch] = useState<string>('')
 
   useEffect(() => {
     if (!season) return
+    if (isAdmin) {
+      setIdentityLoaded(true)
+      return
+    }
     const stored = localStorage.getItem(IDENTITY_KEY)
     if (!stored) {
       router.replace(`/${season}/identity?redirect=/${season}/swap-drivers`)
@@ -50,11 +63,36 @@ const SwapDrivers = ({
     }
     setConstructorId(val.id)
     setIdentityLoaded(true)
-  }, [season])
+  }, [season, isAdmin])
 
+  const managingConstructor = constructors.find((c) => c.id === constructorId)
+  const currentDrivers = selectedDrivers.find(
+    (cd) => cd.constructor_id === constructorId
+  )
+  const currentDriverList = currentDrivers
+    ? [currentDrivers.driver_one, currentDrivers.driver_two]
+    : []
+  const oldDriver = currentDriverList.find((d) => d?.id === oldDriverId)
+  const newDriver = availableDrivers.find((d) => d.id === newDriverId)
   const disableButton =
     !constructorId || !oldDriverId || !newDriverId || isSwapping
-  const managingConstructor = constructors.find((c) => c.id === constructorId)
+
+  const normalized = managingConstructor
+    ? normalizeConstructorName(managingConstructor.name)
+    : null
+  const colors = normalized ? COLORS_BY_CONSTRUCTOR[season]?.[normalized] : null
+  const primaryColor = colors?.primary ?? '#6b7280'
+  const { red, blue, green } = hexRgb(primaryColor)
+  const hasImages = HAS_IMAGES_BY_SEASON[season]
+  const carImageUrl = normalized
+    ? hasImages
+      ? getCloudinaryCarUrl(normalized, season, { format: 'webp' })
+      : rgbDataURL(red, green, blue)
+    : rgbDataURL(red, green, blue)
+
+  const filteredAvailableDrivers = availableDrivers.filter((d) =>
+    makeName(d).toLowerCase().includes(driverSearch.toLowerCase())
+  )
 
   if (!identityLoaded) {
     return (
@@ -68,132 +106,218 @@ const SwapDrivers = ({
 
   return (
     <Layout documentTitle='Swap Drivers' description='Swap Drivers'>
-      <div className='relative mx-2 mt-4 sm:mx-4'>
+      {/* Hero banner */}
+      {managingConstructor && (
+        <div
+          className='bg-cover bg-center w-screen absolute h-80 sm:h-[336px] left-0 top-[64px] sm:top-[72px] shadow-inset-black-7'
+          style={{ backgroundImage: `url(${carImageUrl})` }}
+        />
+      )}
+
+      {/* Managing constructor heading */}
+      <div className='relative mb-6'>
+        <h1 className='text-4xl font-bold font-primary uppercase text-gray-900 sm:text-gray-200 md:text-5xl lg:text-6xl'>
+          {managingConstructor ? managingConstructor.name : 'Swap Drivers'}
+        </h1>
         {managingConstructor && (
-          <div className='mb-8 flex flex-col items-center text-center'>
-            <div className='px-8 py-5 bg-gray-800 rounded-lg border border-gray-600'>
-              <p className='text-gray-400 font-secondary text-sm uppercase tracking-wide mb-1'>
-                Managing
-              </p>
-              <p className='text-gray-100 font-primary uppercase text-4xl'>
-                {managingConstructor.name}
-              </p>
-              <p className='text-gray-300 font-secondary text-lg mt-1'>
-                {managingConstructor.team_principal}
-              </p>
-            </div>
-          </div>
+          <p className='text-2xl leading-none tracking-wide text-gray-600 font-tertiary sm:text-gray-300'>
+            Managing
+          </p>
         )}
+      </div>
 
-        <div className='grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto'>
-          <div className='bg-gray-800 rounded-lg p-6 border border-gray-700'>
-            <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
-              Step 1
-            </p>
-            <h3 className='mb-4 text-2xl font-secondary text-gray-100'>
-              Constructor
-            </h3>
-            <select
-              name='Constructor'
-              id='Constructor'
-              value={constructorId ?? ''}
-              disabled={!isAdmin}
-              onChange={(ev) => {
-                setConstructorId(+ev.target.value)
-                setOldDriverId(undefined)
-                setNewDriverId(undefined)
-                setSwapResponse(undefined)
-              }}
-              className='bg-gray-700 text-gray-100 border border-gray-600 rounded-lg w-full p-3 font-secondary text-lg disabled:opacity-70 disabled:cursor-default'
-            >
-              <option value='' disabled>
-                Select
+      {/* Admin-only constructor picker */}
+      {isAdmin && (
+        <div className='relative mb-6'>
+          <select
+            value={constructorId ?? ''}
+            onChange={(ev) => {
+              setConstructorId(+ev.target.value)
+              setOldDriverId(undefined)
+              setNewDriverId(undefined)
+              setSwapResponse(undefined)
+            }}
+            className='bg-gray-700 text-gray-100 border border-gray-600 rounded-lg p-3 font-secondary text-lg'
+          >
+            <option value='' disabled>
+              Select Constructor
+            </option>
+            {constructors.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
               </option>
-              {constructors.map((constructor) => (
-                <option key={constructor.id} value={constructor.id}>
-                  {constructor.name}
-                </option>
-              ))}
-            </select>
-          </div>
+            ))}
+          </select>
+        </div>
+      )}
 
-          <div className='bg-gray-800 rounded-lg p-6 border border-gray-700'>
-            <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
-              Step 2
-            </p>
-            <h3 className='mb-4 text-2xl font-secondary text-gray-100'>
-              Driver to Replace
-            </h3>
-            <select
-              name='Old Driver'
-              id='Old Driver'
-              value={oldDriverId ?? ''}
-              disabled={!constructorId}
-              onChange={(ev) => {
-                setOldDriverId(+ev.target.value)
-                setNewDriverId(undefined)
-                setSwapResponse(undefined)
-              }}
-              className='bg-gray-700 text-gray-100 border border-gray-600 rounded-lg w-full p-3 font-secondary text-lg disabled:opacity-50'
-            >
-              <option value='' disabled>
-                Select
-              </option>
-              {selectedDrivers
-                .filter((cd) => cd.constructor_id === constructorId)
-                .map((cd) => (
-                  <Fragment key={cd.constructor_id}>
-                    <option value={cd.driver_one.id}>
-                      {makeName(cd.driver_one)}
-                    </option>
-                    <option value={cd.driver_two.id}>
-                      {makeName(cd.driver_two)}
-                    </option>
-                  </Fragment>
-                ))}
-            </select>
-          </div>
-
-          <div className='bg-gray-800 rounded-lg p-6 border border-gray-700'>
-            <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
-              Step 3
-            </p>
-            <h3 className='mb-4 text-2xl font-secondary text-gray-100'>
-              New Driver
-            </h3>
-            <select
-              name='New Driver'
-              id='New Driver'
-              value={newDriverId ?? ''}
-              disabled={!constructorId || !oldDriverId}
-              onChange={(ev) => {
-                setNewDriverId(+ev.target.value)
-                setSwapResponse(undefined)
-              }}
-              className='bg-gray-700 text-gray-100 border border-gray-600 rounded-lg w-full p-3 font-secondary text-lg disabled:opacity-50'
-            >
-              <option value='' disabled>
-                Select
-              </option>
-              {availableDrivers.map((driver) => (
-                <option key={driver.id} value={driver.id}>
-                  {makeName(driver)}
-                </option>
-              ))}
-            </select>
+      <div className='relative grid grid-cols-1 md:grid-cols-3 gap-6 w-full'>
+        {/* Column 1: Drop a driver */}
+        <div className='bg-gray-800 rounded-lg p-6 border border-gray-700'>
+          <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
+            Step 1
+          </p>
+          <h3 className='mb-4 text-2xl font-secondary text-gray-100'>Drop</h3>
+          <div className='flex flex-col gap-3'>
+            {currentDriverList.map((driver) => {
+              if (!driver) return null
+              const isSelected = driver.id === oldDriverId
+              return (
+                <button
+                  key={driver.id}
+                  onClick={() => {
+                    setOldDriverId(isSelected ? undefined : driver.id)
+                    setNewDriverId(undefined)
+                    setSwapResponse(undefined)
+                  }}
+                  className={`flex items-center gap-3 p-2 rounded-lg transition-colors hover:bg-gray-700 border-2 ${
+                    isSelected ? 'border-red-500' : 'border-transparent'
+                  }`}
+                >
+                  <div className='relative rounded overflow-hidden w-12 h-12 flex-shrink-0 bg-gray-700'>
+                    <Image
+                      src={driver.image_url ?? ''}
+                      alt={makeName(driver)}
+                      fill
+                      className='object-cover object-top'
+                    />
+                  </div>
+                  <span className='font-primary uppercase text-gray-100 text-lg flex-1 text-left'>
+                    {makeName(driver)}
+                  </span>
+                  <span
+                    className='text-2xl font-bold leading-none w-8 h-8 flex items-center justify-center rounded-full flex-shrink-0'
+                    style={{
+                      backgroundColor: isSelected ? '#ef4444' : '#4b5563',
+                      color: '#fff',
+                    }}
+                  >
+                    −
+                  </span>
+                </button>
+              )
+            })}
+            {currentDriverList.length === 0 && (
+              <p className='text-gray-500 font-secondary text-sm'>
+                Select a constructor first
+              </p>
+            )}
           </div>
         </div>
 
-        <div className='flex items-center justify-center mt-8'>
+        {/* Column 2: Add a driver */}
+        <div className='bg-gray-800 rounded-lg p-6 border border-gray-700'>
+          <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
+            Step 2
+          </p>
+          <h3 className='mb-4 text-2xl font-secondary text-gray-100'>Add</h3>
+          <input
+            type='text'
+            placeholder='Search...'
+            value={driverSearch}
+            onChange={(e) => setDriverSearch(e.target.value)}
+            className='mb-3 bg-gray-700 text-gray-100 border border-gray-600 rounded-lg p-2 font-secondary text-sm w-full placeholder-gray-500'
+          />
+          <div className='flex flex-col gap-2 max-h-64 overflow-y-auto pr-1'>
+            {filteredAvailableDrivers.map((driver) => {
+              const isSelected = driver.id === newDriverId
+              return (
+                <button
+                  key={driver.id}
+                  disabled={!oldDriverId}
+                  onClick={() => {
+                    setNewDriverId(isSelected ? undefined : driver.id)
+                    setSwapResponse(undefined)
+                  }}
+                  className={`flex items-center gap-3 p-2 rounded-lg transition-colors hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed border-2 ${
+                    isSelected ? 'border-green-500' : 'border-transparent'
+                  }`}
+                >
+                  <div className='relative rounded overflow-hidden w-10 h-10 flex-shrink-0 bg-gray-700'>
+                    <Image
+                      src={driver.image_url ?? ''}
+                      alt={makeName(driver)}
+                      fill
+                      className='object-cover object-top'
+                    />
+                  </div>
+                  <span className='font-primary uppercase text-gray-100 text-base flex-1 text-left'>
+                    {makeName(driver)}
+                  </span>
+                  <span
+                    className='text-xl font-bold leading-none w-7 h-7 flex items-center justify-center rounded-full flex-shrink-0'
+                    style={{
+                      backgroundColor: isSelected ? '#22c55e' : '#4b5563',
+                      color: '#fff',
+                    }}
+                  >
+                    +
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Column 3: Confirm */}
+        <div className='bg-gray-800 rounded-lg p-6 border border-gray-700 flex flex-col'>
+          <p className='text-gray-500 font-secondary text-sm uppercase tracking-wide mb-2'>
+            Step 3
+          </p>
+          <h3 className='mb-4 text-2xl font-secondary text-gray-100'>
+            Confirm
+          </h3>
+          <div className='flex flex-col gap-4 flex-1'>
+            <div className='flex items-center gap-3'>
+              <div className='relative rounded overflow-hidden w-12 h-12 flex-shrink-0 bg-gray-700'>
+                {oldDriver && (
+                  <Image
+                    src={oldDriver.image_url ?? ''}
+                    alt={makeName(oldDriver)}
+                    fill
+                    className='object-cover object-top'
+                  />
+                )}
+              </div>
+              <span className='font-primary uppercase font-bold text-red-400 text-lg flex-1'>
+                {oldDriver ? (
+                  makeName(oldDriver)
+                ) : (
+                  <span className='text-gray-600'>—</span>
+                )}
+              </span>
+            </div>
+            <span className='text-gray-500 text-xl'>↓</span>
+            <div className='flex items-center gap-3'>
+              <div className='relative rounded overflow-hidden w-12 h-12 flex-shrink-0 bg-gray-700'>
+                {newDriver && (
+                  <Image
+                    src={newDriver.image_url ?? ''}
+                    alt={makeName(newDriver)}
+                    fill
+                    className='object-cover object-top'
+                  />
+                )}
+              </div>
+              <span className='font-primary uppercase font-bold text-green-400 text-lg flex-1'>
+                {newDriver ? (
+                  makeName(newDriver)
+                ) : (
+                  <span className='text-gray-600'>—</span>
+                )}
+              </span>
+            </div>
+          </div>
           <button
             type='button'
-            className='px-6 py-3 mb-2 text-xl text-white bg-green-700 rounded-lg focus:outline-none hover:bg-green-800 focus:ring-4 focus:ring-green-300 dark:bg-green-600 dark:hover:bg-green-700 dark:focus:ring-green-800 disabled:opacity-50 disabled:cursor-not-allowed font-secondary'
             disabled={disableButton}
             onClick={async () => {
               setIsSwapping(true)
               try {
                 const resp = await fetch(
-                  `/api/drivers/swap?season=${season}&constructor_id=${constructorId}&old_driver_id=${oldDriverId}&new_driver_id=${newDriverId}`,
+                  `/api/drivers/swap?season=${season}&constructor_id=${constructorId}&old_driver_id=${oldDriverId}&new_driver_id=${newDriverId}${
+                    isAdmin ? '&admin=true' : ''
+                  }`,
                   { method: 'POST' }
                 )
                 const data = await resp.json()
@@ -207,21 +331,21 @@ const SwapDrivers = ({
                 setIsSwapping(false)
               }
             }}
+            className='mt-6 w-full px-6 py-3 text-xl text-white bg-green-700 rounded-lg hover:bg-green-800 focus:outline-none focus:ring-4 focus:ring-green-300 disabled:opacity-50 disabled:cursor-not-allowed font-secondary'
           >
-            {isSwapping ? 'Swapping...' : 'Swap'}
+            {isSwapping ? 'Swapping...' : 'Confirm Swap'}
           </button>
+          {swapResponse?.message && (
+            <p
+              className={`text-base font-secondary mt-3 ${
+                swapResponse.success ? 'text-green-400' : 'text-red-400'
+              }`}
+            >
+              {swapResponse.success ? '✓ ' : '✗ '}
+              {swapResponse.message}
+            </p>
+          )}
         </div>
-
-        {swapResponse?.message && (
-          <p
-            className={`text-center text-xl font-secondary mt-2 ${
-              swapResponse.success ? 'text-green-400' : 'text-red-400'
-            }`}
-          >
-            {swapResponse.success ? '✓ ' : '✗ '}
-            {swapResponse.message}
-          </p>
-        )}
       </div>
     </Layout>
   )
@@ -249,12 +373,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         driver_one:driver_one_id(
           id,
           first_name,
-          last_name
+          last_name,
+          image_url
         ),
         driver_two:driver_two_id(
           id,
           first_name,
-          last_name
+          last_name,
+          image_url
         ),
         constructor_id,
         season!inner(year)`
@@ -268,6 +394,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         id,
         first_name,
         last_name,
+        image_url,
         is_full_time,
         season!inner(year)`
       )

--- a/client/pages/[season]/swap-drivers.tsx
+++ b/client/pages/[season]/swap-drivers.tsx
@@ -322,6 +322,11 @@ const SwapDrivers = ({
                 )
                 const data = await resp.json()
                 setSwapResponse(data)
+                if (data.success) {
+                  setOldDriverId(undefined)
+                  setNewDriverId(undefined)
+                  setDriverSearch('')
+                }
               } catch {
                 setSwapResponse({
                   success: false,

--- a/client/pages/[season]/swap-drivers.tsx
+++ b/client/pages/[season]/swap-drivers.tsx
@@ -45,6 +45,8 @@ const SwapDrivers = ({
   const [driverSearch, setDriverSearch] = useState<string>('')
   const [localSelectedDrivers, setLocalSelectedDrivers] =
     useState(selectedDrivers)
+  const [localAvailableDrivers, setLocalAvailableDrivers] =
+    useState(availableDrivers)
 
   useEffect(() => {
     if (!season) return
@@ -75,7 +77,7 @@ const SwapDrivers = ({
     ? [currentDrivers.driver_one, currentDrivers.driver_two]
     : []
   const oldDriver = currentDriverList.find((d) => d?.id === oldDriverId)
-  const newDriver = availableDrivers.find((d) => d.id === newDriverId)
+  const newDriver = localAvailableDrivers.find((d) => d.id === newDriverId)
   const disableButton =
     !constructorId || !oldDriverId || !newDriverId || isSwapping
 
@@ -92,7 +94,7 @@ const SwapDrivers = ({
       : rgbDataURL(red, green, blue)
     : rgbDataURL(red, green, blue)
 
-  const filteredAvailableDrivers = availableDrivers.filter((d) =>
+  const filteredAvailableDrivers = localAvailableDrivers.filter((d) =>
     makeName(d).toLowerCase().includes(driverSearch.toLowerCase())
   )
 
@@ -341,6 +343,13 @@ const SwapDrivers = ({
                       }
                     })
                   )
+                  setLocalAvailableDrivers((prev) => {
+                    const withoutNew = prev.filter((d) => d.id !== newDriverId)
+                    return [
+                      ...withoutNew,
+                      oldDriver! as unknown as DriverWithSeason,
+                    ].sort((a, b) => a.last_name.localeCompare(b.last_name))
+                  })
                   setOldDriverId(undefined)
                   setNewDriverId(undefined)
                   setDriverSearch('')

--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -1,4 +1,3 @@
-import { normalizeConstructorName } from '@/helpers/cars'
 import { makeName } from '@/helpers/utils'
 import { supabase } from '@/lib/database'
 import { Driver } from '@/types/Driver'
@@ -63,38 +62,54 @@ export default async function handler(
       .limit(1)
       .returns<ConstructorDriverWithJoins>()
       .single()
+    const constructorDriver =
+      constructorDriverResp as unknown as ConstructorDriverWithJoins
 
-    if (!constructorDriverResp) {
+    if (!constructorDriver) {
       return createResponse(400, 'Constructor does not exist')
     }
 
-    const constructorDriver =
-      constructorDriverResp as ConstructorDriverWithJoins
+    const [
+      { data: oldDriverResp },
+      { data: newDriverResp },
+      { data: existingDriverMatch },
+    ] = await Promise.all([
+      supabase
+        .from('driver')
+        .select(`id, first_name, last_name, abbreviation, season!inner(year)`)
+        .eq('id', old_driver_id)
+        .eq('season.year', season)
+        .limit(1)
+        .returns<Driver>()
+        .single(),
+      supabase
+        .from('driver')
+        .select(`id, first_name, last_name, abbreviation, season!inner(year)`)
+        .eq('id', new_driver_id)
+        .eq('season.year', season)
+        .limit(1)
+        .returns<Driver>()
+        .single(),
+      supabase
+        .from('constructor_driver')
+        .select(`id, season!inner(year)`)
+        .eq('season.year', season)
+        .or(
+          `driver_one_id.eq.${new_driver_id},driver_two_id.eq.${new_driver_id}`
+        )
+        .limit(1),
+    ])
 
-    const { data: oldDriver } = await supabase
-      .from('driver')
-      .select(
-        `
-        id,
-        first_name,
-        last_name,
-        abbreviation,
-        season!inner(year)
-      `
-      )
-      .eq('id', old_driver_id)
-      .eq('season.year', season)
-      .limit(1)
-      .returns<Driver>()
-      .single()
+    const oldDriver = oldDriverResp as unknown as Driver
+    const newDriver = newDriverResp as unknown as Driver
 
     if (!oldDriver) {
       return createResponse(400, 'Old Driver does not exist')
     }
 
     if (
-      constructorDriver.driver_one_id !== (oldDriver as Driver).id &&
-      constructorDriver.driver_two_id !== (oldDriver as Driver).id
+      constructorDriver.driver_one_id !== oldDriver.id &&
+      constructorDriver.driver_two_id !== oldDriver.id
     ) {
       return createResponse(
         400,
@@ -102,38 +117,14 @@ export default async function handler(
       )
     }
 
-    const { data: newDriver } = await supabase
-      .from('driver')
-      .select(
-        `
-        id,
-        abbreviation,
-        first_name,
-        last_name,
-        season!inner(year)
-      `
-      )
-      .eq('id', new_driver_id)
-      .eq('season.year', season)
-      .limit(1)
-      .returns<Driver>()
-      .single()
-
     if (!newDriver) {
       return createResponse(400, 'New Driver does not exist')
     }
 
-    const { data: existingDriverMatch } = await supabase
-      .from('constructor_driver')
-      .select(`id, season!inner(year)`)
-      .eq('season.year', season)
-      .or(`driver_one_id.eq.${new_driver_id},driver_two_id.eq.${new_driver_id}`)
-      .limit(1)
-
     if (existingDriverMatch && existingDriverMatch.length > 0) {
       return createResponse(
         400,
-        `New Driver is already assigned to a constructor`
+        'New Driver is already assigned to a constructor'
       )
     }
 

--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -25,7 +25,8 @@ export default async function handler(
     return createResponse(405, 'Method not allowed')
   }
 
-  const { season, constructor_id, old_driver_id, new_driver_id } = req.query
+  const { season, constructor_id, old_driver_id, new_driver_id, is_admin } =
+    req.query
 
   if (!season) {
     return createResponse(400, 'Invalid parameters, missing "season"')
@@ -146,6 +147,21 @@ export default async function handler(
 
     if (error) {
       throw new Error(error as any)
+    }
+
+    const { error: transactionError } = await supabase
+      .from('transaction')
+      .insert({
+        constructor_id: constructorDriver.constructor_id,
+        season_id: constructorDriver.season_id,
+        current_driver_id: +old_driver_id,
+        replacement_driver_id: +new_driver_id,
+        transaction_type: 'WAIVER',
+        is_admin: is_admin === 'true',
+      })
+
+    if (transactionError) {
+      console.error('** transaction log error', transactionError)
     }
 
     return res.status(201).json({

--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -51,6 +51,8 @@ export default async function handler(
       .select(
         `
         id,
+        constructor_id,
+        season_id,
         driver_one_id,
         driver_two_id,
         season!inner(year)

--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -25,7 +25,7 @@ export default async function handler(
     return createResponse(405, 'Method not allowed')
   }
 
-  const { season, constructor_id, old_driver_id, new_driver_id, is_admin } =
+  const { season, constructor_id, old_driver_id, new_driver_id, admin } =
     req.query
 
   if (!season) {
@@ -157,7 +157,7 @@ export default async function handler(
         current_driver_id: +old_driver_id,
         replacement_driver_id: +new_driver_id,
         transaction_type: 'WAIVER',
-        is_admin: is_admin === 'true',
+        is_admin: admin === 'true',
       })
 
     if (transactionError) {

--- a/client/types/Supabase.ts
+++ b/client/types/Supabase.ts
@@ -277,12 +277,14 @@ export type Database = {
           }
         ]
       }
-      driver_transaction: {
+      transaction: {
         Row: {
           constructor_id: number | null
           created_at: string | null
           current_driver_id: number | null
           id: number
+          is_admin: boolean
+          notes: string | null
           replacement_driver_id: number | null
           season_id: number | null
           transaction_type: string
@@ -292,6 +294,8 @@ export type Database = {
           created_at?: string | null
           current_driver_id?: number | null
           id?: number
+          is_admin?: boolean
+          notes?: string | null
           replacement_driver_id?: number | null
           season_id?: number | null
           transaction_type?: string
@@ -301,6 +305,8 @@ export type Database = {
           created_at?: string | null
           current_driver_id?: number | null
           id?: number
+          is_admin?: boolean
+          notes?: string | null
           replacement_driver_id?: number | null
           season_id?: number | null
           transaction_type?: string


### PR DESCRIPTION
## Summary
- Redesigned swap-drivers page with a 3-column layout (Drop / Add / Confirm) using driver headshots instead of dropdowns
- Added car image hero banner with constructor colors (matches rest of app)
- Admin mode (`?admin=true`) bypasses identity check and shows a top-level constructor picker; non-admin users are pre-locked to their managed team
- After a successful swap, updates the Drop and Add lists client-side without requiring a page reload
- On successful swap, inserts a row into the `transaction` table with `transaction_type = 'WAIVER'` and `is_admin` set based on `?admin=true` query param (defaults to false); insert failure is logged but does not block the success response
- Parallelized independent Supabase queries in swap API with `Promise.all`
- Updated Supabase types to reflect the `transaction` table with `is_admin` and `notes` fields
- Identity page now redirects to the selected team's constructor page instead of standings after picking a team

## Test plan
- [ ] Visit `/[season]/swap-drivers` without identity set — redirects to identity page, then back
- [ ] Swap a driver as a regular user — Drop list updates with new driver, Add list gains the dropped driver
- [ ] Swap a driver with `?admin=true` — constructor picker is shown, transaction row has `is_admin = true`
- [ ] Swap without `?admin=true` — transaction row has `is_admin = false`
- [ ] Select a team on identity page — redirects to that constructor's page

🤖 Generated with [Claude Code](https://claude.com/claude-code)