### PR TITLE
Restrict driver swaps to Tuesday 6am–Saturday 6am ET

### DIFF
--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -25,22 +25,26 @@ export default async function handler(
   }
 
   // Swaps are only allowed Tuesday 6am ET through Saturday 6am ET
+  // Use Intl to resolve ET correctly regardless of server timezone (handles DST too)
   const now = new Date()
-  const etOffset = -5 * 60 // ET is UTC-5 (standard); adjust for DST if needed
-  const etNow = new Date(
-    now.getTime() + (now.getTimezoneOffset() + etOffset) * 60000
-  )
-  const day = etNow.getDay() // 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat
-  const hour = etNow.getHours()
-  const minutesSinceMidnight = hour * 60 + etNow.getMinutes()
-  const tuesdayOpen = minutesSinceMidnight >= 6 * 60 // Tue >= 6:00am
-  const saturdayClose = minutesSinceMidnight < 6 * 60 // Sat < 6:00am
+  const etParts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: false,
+  }).formatToParts(now)
+  const etDay = etParts.find((p) => p.type === 'weekday')!.value // 'Mon', 'Tue', etc.
+  const etHour =
+    parseInt(etParts.find((p) => p.type === 'hour')!.value, 10) % 24
+  const etMinute = parseInt(etParts.find((p) => p.type === 'minute')!.value, 10)
+  const minutesSinceMidnight = etHour * 60 + etMinute
   const isSwapWindowOpen =
-    (day === 2 && tuesdayOpen) ||
-    day === 3 ||
-    day === 4 ||
-    day === 5 ||
-    (day === 6 && saturdayClose)
+    (etDay === 'Tue' && minutesSinceMidnight >= 6 * 60) ||
+    etDay === 'Wed' ||
+    etDay === 'Thu' ||
+    etDay === 'Fri' ||
+    (etDay === 'Sat' && minutesSinceMidnight < 6 * 60)
 
   if (!isSwapWindowOpen) {
     return createResponse(

--- a/client/pages/api/drivers/swap.ts
+++ b/client/pages/api/drivers/swap.ts
@@ -24,6 +24,31 @@ export default async function handler(
     return createResponse(405, 'Method not allowed')
   }
 
+  // Swaps are only allowed Tuesday 6am ET through Saturday 6am ET
+  const now = new Date()
+  const etOffset = -5 * 60 // ET is UTC-5 (standard); adjust for DST if needed
+  const etNow = new Date(
+    now.getTime() + (now.getTimezoneOffset() + etOffset) * 60000
+  )
+  const day = etNow.getDay() // 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat
+  const hour = etNow.getHours()
+  const minutesSinceMidnight = hour * 60 + etNow.getMinutes()
+  const tuesdayOpen = minutesSinceMidnight >= 6 * 60 // Tue >= 6:00am
+  const saturdayClose = minutesSinceMidnight < 6 * 60 // Sat < 6:00am
+  const isSwapWindowOpen =
+    (day === 2 && tuesdayOpen) ||
+    day === 3 ||
+    day === 4 ||
+    day === 5 ||
+    (day === 6 && saturdayClose)
+
+  if (!isSwapWindowOpen) {
+    return createResponse(
+      403,
+      'Driver swaps are only allowed Tuesday 6am ET through Saturday 6am ET'
+    )
+  }
+
   const { season, constructor_id, old_driver_id, new_driver_id, admin } =
     req.query
 


### PR DESCRIPTION
## Summary
- Swaps are only permitted **Tuesday 6:00am ET through Saturday 6:00am ET**
- Requests outside the window return `403` with message: `"Driver swaps are only allowed Tuesday 6am ET through Saturday 6am ET"`
- Uses `Intl.DateTimeFormat` with `America/New_York` — correct on any server timezone, handles EST/EDT automatically
- Adds `% 24` guard for midnight edge case on older runtimes

## Test plan
- [ ] Attempt a swap during the window (Tue 6am – Sat 6am ET) — succeeds as normal
- [ ] Attempt a swap outside the window (Sat 6am+, Sun, Mon, Tue before 6am) — returns 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)