### PR TITLE
Upgrade fastf1 3.7.0 → 3.8.1 for 2026 season support

### DIFF
--- a/supabase-data-generator/requirements.txt
+++ b/supabase-data-generator/requirements.txt
@@ -6,7 +6,7 @@ charset-normalizer==3.3.2
 contourpy==1.3.0
 cryptography==46.0.5
 cycler==0.12.1
-fastf1==3.7.0
+fastf1==3.8.1
 fonttools==4.60.2
 idna==3.6
 kiwisolver==1.4.7


### PR DESCRIPTION
## Summary
- Upgrades `fastf1` from `3.7.0` to `3.8.1` in `requirements.txt`
- `3.7.0` returned empty pos_data for all 2026 races (2026 Australian GP, China GP)
- Tested locally: `3.8.1` successfully loads full telemetry for 2026 Australian GP (22 drivers)

## Test plan
- [ ] Run `generate_replay_data.py` workflow for 2026 Australian GP and verify full race duration is generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)